### PR TITLE
Skip torrents which have no magnet data

### DIFF
--- a/Contents/Services/URL/BitTorrent/ServiceCode.pys
+++ b/Contents/Services/URL/BitTorrent/ServiceCode.pys
@@ -60,7 +60,7 @@ def MediaObjectsForURL(url):
     if '/movie' in url:
         if json_data and 'torrents' in json_data and 'en' in json_data['torrents']:
             for key, magnet_data in json_data['torrents']['en'].iteritems():
-                if magnet_data['url'] == magnet:
+                if magnet_data and magnet_data['url'] == magnet:
                     json_item          = magnet_data
                     json_item['title'] = common.fix_movie_torrent_title(json_data, key, magnet_data)
                     break
@@ -69,7 +69,7 @@ def MediaObjectsForURL(url):
             for episode_data in json_data['episodes']:
                 if 'torrents' in episode_data:
                     for key, magnet_data in episode_data['torrents'].iteritems():
-                        if magnet_data['url'] == magnet:
+                        if magnet_data and magnet_data['url'] == magnet:
                             json_item          = magnet_data
                             json_item['title'] = common.fix_episode_torrent_title(json_data, episode_data, key, magnet_data)
                             break


### PR DESCRIPTION
Hello, I have problems with watching some of shows because of missing magnet data for some of torrents.

For example, you can check [this request](https://tv-v2.api-fetch.website/show/tt0898266?magnet=magnet%3A%3Fxt%3Durn%3Abtih%3A612fdc1e064e8a8c9902ef4f003d596298d92056%26dn%3DThe.Big.Bang.Theory.S11E08.HDTV.x264-SVA%255Beztv%255D.mkv%255Beztv%255D%26tr%3Dudp%253A%252F%252Ftracker.coppersurfer.tk%253A80%26tr%3Dudp%253A%252F%252Fglotorrents.pw%253A6969%252Fannounce%26tr%3Dudp%253A%252F%252Ftracker.leechers-paradise.org%253A6969%26tr%3Dudp%253A%252F%252Ftracker.opentrackr.org%253A1337%252Fannounce%26tr%3Dudp%253A%252F%252Fexodus.desync.com%253A6969%27) for TBBT episodes.

There are such entries inside **torrents** field, which leads to an exception:

```
{
  '0': None, 
  '1080p': { 'url': 'magnet:?...', 'peers': 0, 'seeds': 0, 'provider': '1080p'}
}
```

This PR should fix that by skipping torrents without magnet data, so that other torrent options will still work .

  